### PR TITLE
chore: Update yarn installation and build commands in gh-pages-deploy.yml

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -20,10 +20,14 @@ jobs:
           node-version: '20'
 
       - name: Install Dependencies
-        run: yarn
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install
 
       - name: Build
-        run: yarn build
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
The code changes in the `.github/workflows/gh-pages-deploy.yml` file update the yarn installation and build commands. Instead of using the `yarn` command, the `borales/actions-yarn@v4` action is now used with the `install` and `build` commands. This ensures that the correct version of yarn is used and improves the reliability of the deployment process.

Based on the recent user commits and repository commits, the commit message follows the established convention of starting with a type, followed by a colon and a brief description of the changes.