### PR TITLE
Update copyright year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 jwaspin
+Copyright (c) 2023-2026 jwaspin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
This pull request makes a minor update to the project license, extending the copyright years.

- Updated the copyright years in the `LICENSE` file from 2025 to 2023-2026.